### PR TITLE
Define a clear format for ACI policy specification

### DIFF
--- a/src/confcom/.gitignore
+++ b/src/confcom/.gitignore
@@ -36,3 +36,5 @@ azext_confcom/bin/*
 **/.coverage
 
 **/htmlcov
+
+!lib/

--- a/src/confcom/azext_confcom/container.py
+++ b/src/confcom/azext_confcom/container.py
@@ -791,12 +791,17 @@ class UserContainerImage(ContainerImage):
     ) -> "UserContainerImage":
         image = super().from_json(container_json)
         image.__class__ = UserContainerImage
+        mount_paths = {m["mountPath"] for m in image.get_mounts()}
         # inject default mounts for user container
-        if (image.base not in config.BASELINE_SIDECAR_CONTAINERS) and (not is_vn2):
-            image.get_mounts().extend(_DEFAULT_MOUNTS)
+        if image.base not in config.BASELINE_SIDECAR_CONTAINERS and not is_vn2:
+            for mount in _DEFAULT_MOUNTS:
+                if mount["mountPath"] not in mount_paths:
+                    image.get_mounts().append(mount)
 
         if (image.base not in config.BASELINE_SIDECAR_CONTAINERS) and (is_vn2):
-            image.get_mounts().extend(_DEFAULT_MOUNTS_VN2)
+            for mount in _DEFAULT_MOUNTS_VN2:
+                if mount["mountPath"] not in mount_paths:
+                    image.get_mounts().append(mount)
 
         # Start with the customer environment rules
         env_rules = copy.deepcopy(_INJECTED_CUSTOMER_ENV_RULES)

--- a/src/confcom/azext_confcom/lib/aci_policy_spec.py
+++ b/src/confcom/azext_confcom/lib/aci_policy_spec.py
@@ -34,12 +34,14 @@ class AciContainerPropertySecurityContextCapabilities:
 
 @dataclass
 class AciContainerPropertySecurityContext:
-    priviledged: bool
-    runAsUser: int
-    runAsGroup: int
-    runAsNonRoot: bool
-    readOnlyRootFilesystem: bool
-    capabilities: AciContainerPropertySecurityContextCapabilities
+    privileged: Optional[bool] = None
+    allowPrivilegeEscalation: Optional[bool] = None
+    runAsUser: Optional[int] = None
+    runAsGroup: Optional[int] = None
+    runAsNonRoot: Optional[bool] = None
+    readOnlyRootFilesystem: Optional[bool] = None
+    capabilities: Optional[AciContainerPropertySecurityContextCapabilities] = None
+    seccompProfile: Optional[str] = None
 
 
 @dataclass

--- a/src/confcom/azext_confcom/lib/aci_policy_spec.py
+++ b/src/confcom/azext_confcom/lib/aci_policy_spec.py
@@ -1,0 +1,76 @@
+from dataclasses import dataclass
+from typing import Optional
+from typing_extensions import Literal
+
+
+@dataclass
+class AciContainerPropertyEnvVariable:
+    name: str
+    value: str
+    strategy: str
+    required: bool = False
+
+
+@dataclass
+class AciContainerPropertyExecProcesses:
+    command: list[str]
+    signals: Optional[list[str]] = None
+    allow_stdio_access: bool = True
+
+
+@dataclass
+class AciContainerPropertyVolumeMounts:
+    mountPath: str
+    name: Optional[str] = None
+    readonly: bool = False
+    mountType: Optional[Literal["azureFile", "secret", "configMap", "emptyDir"]] = None
+
+
+@dataclass
+class AciContainerPropertySecurityContextCapabilities:
+    add: list[str]
+    drop: list[str]
+
+
+@dataclass
+class AciContainerPropertySecurityContext:
+    priviledged: bool
+    runAsUser: int
+    runAsGroup: int
+    runAsNonRoot: bool
+    readOnlyRootFilesystem: bool
+    capabilities: AciContainerPropertySecurityContextCapabilities
+
+
+@dataclass
+class AciContainerProperties():
+    image: str
+    allowStdioAccess: bool = True
+    environmentVariables: Optional[list[AciContainerPropertyEnvVariable]] = None
+    execProcesses: Optional[list[AciContainerPropertyExecProcesses]] = None
+    volumeMounts: Optional[list[AciContainerPropertyVolumeMounts]] = None
+    securityContext: Optional[AciContainerPropertySecurityContext] = None
+    command: Optional[list[str]] = None
+
+
+# ------------------------------------------------------------------------------
+
+
+@dataclass
+class AciFragmentSpec:
+    feed: str
+    issuer: str
+    minimum_svn: str
+    includes: list[Literal["containers", "fragments"]]
+
+
+@dataclass
+class AciContainerSpec:
+    name: str
+    properties: AciContainerProperties
+
+
+@dataclass
+class AciPolicySpec:
+    fragments: Optional[list[AciFragmentSpec]]
+    containers: Optional[list[AciContainerSpec]]

--- a/src/confcom/azext_confcom/lib/arm_to_aci_policy_spec.py
+++ b/src/confcom/azext_confcom/lib/arm_to_aci_policy_spec.py
@@ -1,0 +1,217 @@
+from typing import Iterator, Optional
+import json
+import re
+from azext_confcom import config
+from azext_confcom.template_util import (
+    get_probe_exec_processes,
+    is_sidecar,
+    process_configmap,
+    process_env_vars_from_template,
+    process_mounts
+)
+from azext_confcom.lib.aci_policy_spec import (
+    AciContainerPropertyEnvVariable,
+    AciContainerPropertyExecProcesses,
+    AciContainerPropertySecurityContext,
+    AciContainerPropertySecurityContextCapabilities,
+    AciContainerPropertyVolumeMounts,
+    AciContainerSpec,
+    AciContainerProperties,
+    AciFragmentSpec,
+    AciPolicySpec,
+)
+
+def eval_variables(
+    arm_template: dict,
+    arm_template_parameters: dict,
+) -> dict:
+
+    def parse_arm_parameters(
+        arm_template_parameters: dict
+    ) -> Iterator[tuple[str, str]]:
+        for param_name, param in arm_template_parameters.get("parameters", {}).items():
+            if "value" in param:
+                yield param_name, param["value"]
+            elif "defaultValue" in param:
+                yield param_name, param["defaultValue"]
+
+    json_str = json.dumps(arm_template)
+    variables = {
+        **arm_template.get("variables", {}),
+        **dict(parse_arm_parameters(arm_template_parameters)),
+    }
+
+    pattern = re.compile(r"\[variables\('([^']+)'\)\]")
+
+    def _replace(match):
+        var_name = match.group(1)
+        if var_name not in variables:
+            return match.group(0)
+        val = variables[var_name]
+        if isinstance(val, str):
+            return json.dumps(val)[1:-1]
+        return json.dumps(val)
+
+    replaced = pattern.sub(_replace, json_str)
+    return json.loads(replaced)
+
+
+EVAL_FUNCS = [
+        eval_variables,
+]
+
+
+def arm_container_env_to_aci_policy_spec_env(
+    container_properties: dict,
+    approve_wildcards: bool,
+) -> Iterator[AciContainerPropertyEnvVariable]:
+
+    for env_var in [
+        *process_env_vars_from_template({}, {}, container_properties, approve_wildcards),
+        *config.OPENGCS_ENV_RULES,
+        *config.FABRIC_ENV_RULES,
+        *config.MANAGED_IDENTITY_ENV_RULES,
+        *config.ENABLE_RESTART_ENV_RULE,
+    ]:
+        yield AciContainerPropertyEnvVariable(**env_var)
+
+
+def arm_container_volumes_to_aci_policy_spec_volumes(
+    container_properties: dict,
+    container_group_volumes: list[dict],
+) -> Iterator[AciContainerPropertyVolumeMounts]:
+
+    for vol_mount in [
+        *process_mounts(container_properties, container_group_volumes),
+        *process_configmap(container_properties),
+        *(
+                config.DEFAULT_MOUNTS_USER
+            if not is_sidecar(container_properties["image"]) else []
+        )
+    ]:
+        yield AciContainerPropertyVolumeMounts(
+                **{k: v for k, v in vol_mount.items() if v is not None})
+
+
+def arm_container_exec_procs_to_aci_policy_spec_exec_procs(
+    container_properties: dict,
+    debug_mode: bool,
+) -> Iterator[AciContainerPropertyVolumeMounts]:
+
+    for exec_process in [
+        *container_properties.get("execProcesses", []),
+        *get_probe_exec_processes(container_properties),
+        *(config.DEBUG_MODE_SETTINGS.get("execProcesses", []) if debug_mode else []),
+    ]:
+        yield AciContainerPropertyExecProcesses(**exec_process)
+
+
+def arm_container_props_to_aci_policy_spec_props(
+    container_group: dict,
+    container_properties: dict,
+    debug_mode: bool,
+    allow_stdio_access: bool,
+    approve_wildcards: bool,
+) -> AciContainerProperties:
+
+    return AciContainerProperties(
+        image=container_properties["image"],
+        command=container_properties.get("command", []),
+        allowStdioAccess=allow_stdio_access,
+        environmentVariables=list(arm_container_env_to_aci_policy_spec_env(
+            container_properties=container_properties,
+            approve_wildcards=approve_wildcards,
+        )),
+        volumeMounts=list(arm_container_volumes_to_aci_policy_spec_volumes(
+            container_properties=container_properties,
+            container_group_volumes=container_group["properties"].get("volumes", [])),
+        ),
+        execProcesses=list(arm_container_exec_procs_to_aci_policy_spec_exec_procs(
+            container_properties=container_properties,
+            debug_mode=debug_mode,
+        )),
+        securityContext=AciContainerPropertySecurityContext(
+            capabilities=AciContainerPropertySecurityContextCapabilities(
+                add=container_properties["securityContext"]["capabilities"].get("add", []),
+                drop=container_properties["securityContext"]["capabilities"].get("drop", []),
+            ) if "capabilities" in container_properties["securityContext"] else None,
+            **container_properties["securityContext"]
+        ) if "securityContext" in container_properties else None,
+    )
+
+
+def arm_container_to_aci_policy_spec_container(
+    container_group: dict,
+    container: dict,
+    debug_mode: bool,
+    allow_stdio_access: bool,
+    approve_wildcards: bool,
+) -> AciContainerSpec:
+
+    return AciContainerSpec(
+        name=container["name"],
+        properties=arm_container_props_to_aci_policy_spec_props(
+            container_group=container_group,
+            container_properties=container["properties"],
+            debug_mode=debug_mode,
+            allow_stdio_access=allow_stdio_access,
+            approve_wildcards=approve_wildcards,
+        ),
+    )
+
+
+def arm_container_group_to_aci_policy_spec_fragments(
+    container_group: dict,
+) -> Iterator[AciFragmentSpec]:
+
+    for fragment in container_group.get("properties", {}).get("standaloneFragments", []):
+        yield AciFragmentSpec(**fragment)
+
+
+def arm_container_group_to_aci_policy_spec(
+    container_group: dict,
+    fragments: list[AciFragmentSpec],
+    debug_mode: bool,
+    allow_stdio_access: bool,
+    approve_wildcards: bool,
+) -> AciPolicySpec:
+
+    return AciPolicySpec(
+        fragments=[
+            *fragments,
+            *arm_container_group_to_aci_policy_spec_fragments(container_group),
+        ],
+        containers=[
+            arm_container_to_aci_policy_spec_container(
+                container_group=container_group,
+                container=c,
+                debug_mode=debug_mode,
+                allow_stdio_access=allow_stdio_access,
+                approve_wildcards=approve_wildcards,
+            )
+            for c in container_group.get("properties", {}).get("containers", [])
+        ]
+    )
+
+
+def arm_to_aci_policy_spec(
+    arm_template: dict,
+    arm_template_parameters: dict,
+    fragments: list[AciFragmentSpec],
+    debug_mode: bool = False,
+    allow_stdio_access: bool = True,
+    approve_wildcards: bool = False,
+) -> Iterator[AciPolicySpec]:
+
+    for eval_func in EVAL_FUNCS:
+        arm_template = eval_func(arm_template, arm_template_parameters)
+
+    for resource in arm_template.get("resources", []):
+        parser = {
+            "Microsoft.ContainerInstance/containerGroups": arm_container_group_to_aci_policy_spec,
+            "Microsoft.ContainerInstance/containerGroupProfiles": arm_container_group_to_aci_policy_spec,
+        }.get(resource["type"], (lambda r, f, d, io, w: None))
+
+        spec = parser(resource, fragments, debug_mode, allow_stdio_access, approve_wildcards)
+        if spec is not None:
+            yield spec

--- a/src/confcom/azext_confcom/lib/arm_to_aci_policy_spec.py
+++ b/src/confcom/azext_confcom/lib/arm_to_aci_policy_spec.py
@@ -29,6 +29,7 @@ def get_parameters(
     return {
         parameter_key: (
             arm_template_parameters.get("parameters", {}).get(parameter_key, {}).get("value")
+            or arm_template.get("parameters", {}).get(parameter_key, {}).get("value")
             or arm_template.get("parameters", {}).get(parameter_key, {}).get("defaultValue")
         )
         for parameter_key in arm_template.get("parameters", {}).keys()

--- a/src/confcom/azext_confcom/lib/image_refs_to_aci_policy_spec.py
+++ b/src/confcom/azext_confcom/lib/image_refs_to_aci_policy_spec.py
@@ -1,0 +1,34 @@
+from azext_confcom.lib.aci_policy_spec import (
+    AciContainerSpec,
+    AciContainerProperties,
+    AciFragmentSpec,
+    AciPolicySpec,
+)
+
+
+def image_ref_to_aci_container_spec(
+    image_ref: str,
+) -> AciContainerSpec:
+
+    return AciContainerSpec(
+        name=image_ref,
+        properties=AciContainerProperties(
+            image=image_ref,
+        )
+    )
+
+
+def image_refs_to_aci_policy_spec(
+    image_refs: list[str],
+    fragments: list[AciFragmentSpec],
+) -> AciPolicySpec:
+
+    return AciPolicySpec(
+        fragments=[
+            *fragments,
+        ],
+        containers=[
+            image_ref_to_aci_container_spec(image_ref)
+            for image_ref in image_refs
+        ]
+    )

--- a/src/confcom/azext_confcom/security_policy.py
+++ b/src/confcom/azext_confcom/security_policy.py
@@ -877,6 +877,11 @@ def load_policy_from_json(
 
         envs += process_env_vars_from_config(container_properties)
 
+        if debug_mode:
+            for exec_process in config.DEBUG_MODE_SETTINGS.get(config.ACI_FIELD_CONTAINERS_EXEC_PROCESSES, []):
+                if exec_process not in exec_processes:
+                    exec_processes.append(exec_process)
+
         output_containers.append(
             {
                 config.ACI_FIELD_CONTAINERS_ID: image_name,
@@ -888,10 +893,7 @@ def load_policy_from_json(
                     container_properties, config.ACI_FIELD_TEMPLATE_COMMAND
                 ) or [],
                 config.ACI_FIELD_CONTAINERS_MOUNTS: mounts,
-                config.ACI_FIELD_CONTAINERS_EXEC_PROCESSES: exec_processes
-                + config.DEBUG_MODE_SETTINGS.get(config.ACI_FIELD_CONTAINERS_EXEC_PROCESSES)
-                if debug_mode
-                else exec_processes,
+                config.ACI_FIELD_CONTAINERS_EXEC_PROCESSES: exec_processes,
                 config.ACI_FIELD_CONTAINERS_SIGNAL_CONTAINER_PROCESSES: [],
                 config.ACI_FIELD_CONTAINERS_ALLOW_STDIO_ACCESS: not disable_stdio,
                 config.ACI_FIELD_CONTAINERS_SECURITY_CONTEXT: case_insensitive_dict_get(

--- a/src/confcom/azext_confcom/security_policy.py
+++ b/src/confcom/azext_confcom/security_policy.py
@@ -666,9 +666,8 @@ def load_policy_from_arm_template_str(
                 debug_mode,
                 disable_stdio,
                 infrastructure_svn,
-                # This statement covers both if fragments are excluded with
-                # the flag, and the per container group annotation
-                not all(fragment in policy_spec.fragments for fragment in fragments),
+                # Fragments are already parsed
+                True,
             ))
     except Exception as e:
         eprint(f"Error processing ARM template: {e}")

--- a/src/confcom/azext_confcom/security_policy.py
+++ b/src/confcom/azext_confcom/security_policy.py
@@ -8,7 +8,10 @@ import json
 import warnings
 from enum import Enum, auto
 from typing import Any, Dict, List, Tuple, Union
+from dataclasses import asdict
 
+from azext_confcom.lib.aci_policy_spec import AciFragmentSpec
+from azext_confcom.lib.arm_to_aci_policy_spec import arm_to_aci_policy_spec
 import deepdiff
 from azext_confcom import config, os_util
 from azext_confcom.container import ContainerImage, UserContainerImage
@@ -636,190 +639,46 @@ def load_policy_from_arm_template_str(
     fragment_contents: Any = None,
     exclude_default_fragments: bool = False,
 ) -> List[AciPolicy]:
-    """Function that converts ARM template string to an ACI Policy"""
-    input_arm_json = os_util.load_json_from_str(template_data)
 
-    input_parameter_json = {}
-    if parameter_data:
-        input_parameter_json = os_util.load_json_from_str(parameter_data)
+    aci_policies = []
 
-    # find the image names and extract them from the template
-    arm_resources = case_insensitive_dict_get(
-        input_arm_json, config.ACI_FIELD_RESOURCES
-    )
-
-    if not arm_resources:
-        eprint(f"Field [{config.ACI_FIELD_RESOURCES}] is empty or cannot be found")
-
-    aci_list = [
-        item
-        for item in arm_resources
-        if item["type"] in config.ACI_FIELD_SUPPORTED_RESOURCES
+    fragments = [
+        AciFragmentSpec(
+            feed=fragment["feed"],
+            issuer=fragment["issuer"],
+            includes=fragment["includes"],
+            minimum_svn=infrastructure_svn or fragment["minimum_svn"],
+        )
+        for fragment in config.DEFAULT_REGO_FRAGMENTS
     ]
 
-    if not aci_list:
+    try:
+        for policy_spec in arm_to_aci_policy_spec(
+            arm_template=json.loads(template_data),
+            arm_template_parameters=json.loads(parameter_data) if parameter_data else {},
+            fragments=fragments if not exclude_default_fragments else [],
+            debug_mode=debug_mode,
+            allow_stdio_access=not disable_stdio,
+            approve_wildcards=approve_wildcards,
+        ):
+            aci_policies.append(load_policy_from_json(
+                json.dumps(asdict(policy_spec)),
+                debug_mode,
+                disable_stdio,
+                infrastructure_svn,
+                # This statement covers both if fragments are excluded with
+                # the flag, and the per container group annotation
+                not all(fragment in policy_spec.fragments for fragment in fragments),
+            ))
+    except Exception as e:
+        eprint(f"Error processing ARM template: {e}")
+
+    if len(aci_policies) == 0:
         eprint(
             f'Field ["type"] must contain one of {config.ACI_FIELD_SUPPORTED_RESOURCES}'
         )
 
-    # extract variables and parameters in case we need to do substitutions
-    # while searching for image names
-    all_params = (
-        case_insensitive_dict_get(input_arm_json, config.ACI_FIELD_TEMPLATE_PARAMETERS)
-        or {}
-    )
-
-    get_values_for_params(input_parameter_json, all_params)
-
-    AciPolicy.all_params = all_params
-    AciPolicy.all_vars = case_insensitive_dict_get(input_arm_json, config.ACI_FIELD_TEMPLATE_VARIABLES) or {}
-
-    container_groups = []
-
-    for resource in aci_list:
-        # initialize the list of containers we need to generate policies for
-        containers = []
-        existing_containers = None
-        fragments = None
-        exclude_default_fragments_this_group = exclude_default_fragments
-
-        tags = case_insensitive_dict_get(resource, config.ACI_FIELD_TEMPLATE_TAGS)
-        if tags:
-            exclude_default_fragments_this_group = \
-                case_insensitive_dict_get(tags, config.ACI_FIELD_TEMPLATE_ZERO_SIDECAR)
-            if isinstance(exclude_default_fragments_this_group, str):
-                exclude_default_fragments_this_group = exclude_default_fragments_this_group.lower() == "true"
-
-        container_group_properties = case_insensitive_dict_get(
-            resource, config.ACI_FIELD_TEMPLATE_PROPERTIES
-        )
-        container_list = case_insensitive_dict_get(
-            container_group_properties, config.ACI_FIELD_TEMPLATE_CONTAINERS
-        )
-
-        if not container_list:
-            eprint(
-                f'Field ["{config.POLICY_FIELD_CONTAINERS}"] must be a list of {config.POLICY_FIELD_CONTAINERS}'
-            )
-
-        init_container_list = case_insensitive_dict_get(
-            container_group_properties, config.ACI_FIELD_TEMPLATE_INIT_CONTAINERS
-        )
-        # add init containers to the list of other containers since they aren't treated differently
-        # in the security policy
-        if init_container_list:
-            container_list.extend(init_container_list)
-
-        # these are standalone fragments coming from the ARM template itself
-        standalone_fragments = extract_standalone_fragments(container_group_properties)
-        if standalone_fragments:
-            standalone_fragment_imports = create_list_of_standalone_imports(standalone_fragments)
-            unique_imports = set(rego_imports)
-            for fragment in standalone_fragment_imports:
-                if fragment not in unique_imports:
-                    rego_imports.append(fragment)
-                    unique_imports.add(fragment)
-
-        try:
-            existing_containers, fragments = extract_confidential_properties(
-                container_group_properties
-            )
-        except ValueError as e:
-            if diff_mode:
-                # In diff mode, we raise an error if the base64 policy is malformed
-                eprint(f"Unable to decode existing policy. Please check the base64 encoding.\n{e}")
-            else:
-                # In non-diff mode, we ignore the error and proceed without the policy
-                existing_containers, fragments = ([], [])
-
-        rego_fragments = (
-            copy.deepcopy(config.DEFAULT_REGO_FRAGMENTS)
-            if not exclude_default_fragments_this_group else []
-        )
-        if infrastructure_svn:
-            # assumes the first DEFAULT_REGO_FRAGMENT is always the
-            # infrastructure fragment
-            rego_fragments[0][
-                config.POLICY_FIELD_CONTAINERS_ELEMENTS_REGO_FRAGMENTS_MINIMUM_SVN
-            ] = infrastructure_svn
-        if rego_imports:
-            # error check the rego imports for invalid data types
-            processed_imports = process_fragment_imports(rego_imports)
-            rego_fragments.extend(processed_imports)
-
-        volumes = (
-            case_insensitive_dict_get(
-                container_group_properties, config.ACI_FIELD_TEMPLATE_VOLUMES
-            )
-            or []
-        )
-        if volumes and not isinstance(volumes, list):
-            # parameter definition is in parameter file but not arm template
-            eprint(f'Parameter ["{config.ACI_FIELD_TEMPLATE_VOLUMES}"] must be a list')
-
-        for container in container_list:
-            image_properties = case_insensitive_dict_get(
-                container, config.ACI_FIELD_TEMPLATE_PROPERTIES
-            )
-            image_name = case_insensitive_dict_get(
-                image_properties, config.ACI_FIELD_TEMPLATE_IMAGE
-            )
-
-            # this is guaranteed unique for a valid ARM template
-            container_name = case_insensitive_dict_get(
-                container, config.ACI_FIELD_CONTAINERS_NAME
-            )
-
-            if not image_name:
-                eprint(
-                    f'Field ["{config.ACI_FIELD_TEMPLATE_IMAGE}"] is empty or cannot be found'
-                )
-
-            exec_processes = []
-            extract_probe(exec_processes, image_properties, config.ACI_FIELD_CONTAINERS_READINESS_PROBE)
-            extract_probe(exec_processes, image_properties, config.ACI_FIELD_CONTAINERS_LIVENESS_PROBE)
-
-            containers.append(
-                {
-                    config.ACI_FIELD_CONTAINERS_ID: image_name,
-                    config.ACI_FIELD_CONTAINERS_NAME: container_name,
-                    config.ACI_FIELD_CONTAINERS_CONTAINERIMAGE: image_name,
-                    config.ACI_FIELD_CONTAINERS_ENVS: process_env_vars_from_template(
-                        AciPolicy.all_params, AciPolicy.all_vars, image_properties, approve_wildcards),
-                    config.ACI_FIELD_CONTAINERS_COMMAND: case_insensitive_dict_get(
-                        image_properties, config.ACI_FIELD_TEMPLATE_COMMAND
-                    )
-                    or [],
-                    config.ACI_FIELD_CONTAINERS_MOUNTS: process_mounts(image_properties, volumes)
-                    + process_configmap(image_properties),
-                    config.ACI_FIELD_CONTAINERS_EXEC_PROCESSES: exec_processes
-                    + config.DEBUG_MODE_SETTINGS.get(config.ACI_FIELD_CONTAINERS_EXEC_PROCESSES)
-                    if debug_mode
-                    else exec_processes,
-                    config.ACI_FIELD_CONTAINERS_SIGNAL_CONTAINER_PROCESSES: [],
-                    config.ACI_FIELD_CONTAINERS_ALLOW_STDIO_ACCESS: not disable_stdio,
-                    config.ACI_FIELD_CONTAINERS_SECURITY_CONTEXT: case_insensitive_dict_get(
-                        image_properties, config.ACI_FIELD_TEMPLATE_SECURITY_CONTEXT
-                    ),
-                }
-            )
-
-        container_groups.append(
-            AciPolicy(
-                {
-                    config.ACI_FIELD_VERSION: "1.0",
-                    config.ACI_FIELD_CONTAINERS: containers,
-                    config.ACI_FIELD_TEMPLATE_CCE_POLICY: existing_containers,
-                },
-                disable_stdio=disable_stdio,
-                rego_fragments=rego_fragments,
-                # fallback to default fragments if the policy is not present
-                existing_rego_fragments=fragments,
-                debug_mode=debug_mode,
-                fragment_contents=fragment_contents,
-            )
-        )
-    return container_groups
+    return aci_policies
 
 
 def load_policy_from_arm_template_file(

--- a/src/confcom/azext_confcom/template_util.py
+++ b/src/confcom/azext_confcom/template_util.py
@@ -788,6 +788,12 @@ def extract_probe(exec_processes: List[dict], image_properties: dict, probe: str
                 config.ACI_FIELD_CONTAINERS_SIGNAL_CONTAINER_PROCESSES: [],
             })
 
+def get_probe_exec_processes(image_properties: dict) -> List[dict]:
+    exec_processes: List[dict] = []
+    extract_probe(exec_processes, image_properties, config.ACI_FIELD_CONTAINERS_READINESS_PROBE)
+    extract_probe(exec_processes, image_properties, config.ACI_FIELD_CONTAINERS_LIVENESS_PROBE)
+    return exec_processes
+
 
 def extract_lifecycle_hook(exec_processes: List[dict], image_properties: dict, hook: str):
     lifecycle = case_insensitive_dict_get(

--- a/src/confcom/azext_confcom/template_util.py
+++ b/src/confcom/azext_confcom/template_util.py
@@ -520,7 +520,7 @@ def process_env_vars_from_config(container) -> List[Dict[str, str]]:
             config.ACI_FIELD_CONTAINERS_ENVS_NAME: name,
             config.ACI_FIELD_CONTAINERS_ENVS_VALUE: value,
             config.ACI_FIELD_CONTAINERS_ENVS_STRATEGY:
-                "re2" if case_insensitive_dict_get(env_var, "regex") else "string",
+                env_var.get("strategy", "re2" if (case_insensitive_dict_get(env_var, "regex")) else "string"),
         })
 
     return env_vars


### PR DESCRIPTION
### Why

As part of https://github.com/Azure/azure-cli-extensions/issues/9167 and our ambition to have more modular steps in the policy generation process, it makes sense to have a simple, well defined spec for the JSON which describes the policy to be generated.

I have opted to go with python data classes to define this, it's a python first approach which keeps the code simple, and also allow us to generate docs, json schemas from a single source of truth.

### How

- [x] Define a series of data classes, rooted in `AciPolicySpec` which specifies the format of the json which we use to generate the policy
- [x] Add a couple of example parsers including one for ARM templates
- [x] Update `load_policy_from_arm_template_str()` to use this parser
- [x] Since instances of `AciPolicySpec` are complete including fields which were previously implicitly added at policy gen time, add some code to avoid duplication of these implicit fields.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [x] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

NOTE: Version is currently already bumped by https://github.com/DomAyre/azure-cli-extensions/pull/4 but if that's released before this, we need to bump the version again